### PR TITLE
Update apiVersion for kube exec tasks to v1beta1

### DIFF
--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -7,7 +7,7 @@ provider "helm" {
     host                   = data.aws_eks_cluster.cluster.endpoint
     cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
     exec {
-      api_version = "client.authentication.k8s.io/v1alpha1"
+      api_version = "client.authentication.k8s.io/v1beta1"
       args        = ["eks", "get-token", "--cluster-name", data.aws_eks_cluster.cluster.name]
       command     = "aws"
     }

--- a/eniconfig.tf
+++ b/eniconfig.tf
@@ -11,7 +11,7 @@ provider "kubernetes" {
   cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority[0].data)
   token                  = data.aws_eks_cluster_auth.cluster.token
   exec {
-    api_version = "client.authentication.k8s.io/v1alpha1"
+    api_version = "client.authentication.k8s.io/v1beta1"
     args        = ["eks", "get-token", "--cluster-name", var.cluster_name]
     command     = "aws"
   }


### PR DESCRIPTION
I'm seeing failures because of the use of the evidently deprecated apiVersion v1alpha1 (I can't seem to find an announcement for this being deprecated, but there are numerous of this issue popping up online).

```
helm_release.autoscaler: Refreshing state... [id=autoscaler]

│ Error: Kubernetes cluster unreachable: exec plugin: invalid apiVersion "client.authentication.k8s.io/v1alpha1"
│
│   with helm_release.autoscaler,
│   on autoscaler.tf line 17, in resource "helm_release" "autoscaler":
│   17: resource "helm_release" "autoscaler" {
│

ERRO[0054] 1 error occurred:
	* exit status 1
```