### PR TITLE
WIP: dynamically create ADO-specific node groups

### DIFF
--- a/autoscaler.tf
+++ b/autoscaler.tf
@@ -45,31 +45,51 @@ resource "helm_release" "autoscaler" {
     name  = "autoscalingGroups[1].maxSize"
     value = var.runner_asg_max
   }
-  set {
-    name  = "autoscalingGroups[2].name"
-    value = var.batcave_website_asg_name
+
+  dynamic "set" {
+    for_each = var.batcave_website_asg_name != "" ? [var.batcave_website_asg_name] : []
+    content {
+      name  = "autoscalingGroups[2].name"
+      value = var.batcave_website_asg_name
+    }
   }
-  set {
-    name  = "autoscalingGroups[2].minSize"
-    value = var.batcave_website_asg_min
+  dynamic "set" {
+    for_each = var.batcave_website_asg_name != "" ? [var.batcave_website_asg_name] : []
+    content {
+      name  = "autoscalingGroups[2].minSize"
+      value = var.batcave_website_asg_min
+    }
   }
-  set {
-    name  = "autoscalingGroups[2].maxSize"
-    value = var.batcave_website_asg_max
-  }
-  set {
-    name  = "autoscalingGroups[3].name"
-    value = var.batcave_nightlight_asg_name
-  }
-  set {
-    name  = "autoscalingGroups[3].minSize"
-    value = var.batcave_nightlight_asg_min
-  }
-  set {
-    name  = "autoscalingGroups[3].maxSize"
-    value = var.batcave_nightlight_asg_max
+  dynamic "set" {
+    for_each = var.batcave_website_asg_name != "" ? [var.batcave_website_asg_name] : []
+    content {
+      name  = "autoscalingGroups[2].maxSize"
+      value = var.batcave_website_asg_max
+    }
   }
 
+  dynamic "set" {
+    for_each = var.batcave_nightlight_asg_name != "" ? [var.batcave_nightlight_asg_name] : []
+    content {
+      name  = "autoscalingGroups[3].name"
+      value = var.batcave_nightlight_asg_name
+    }
+  }
+  dynamic "set" {
+    for_each = var.batcave_nightlight_asg_name != "" ? [var.batcave_nightlight_asg_name] : []
+    content {
+      name  = "autoscalingGroups[3].minSize"
+      value = var.batcave_nightlight_asg_min
+    }
+  }
+  dynamic "set" {
+    for_each = var.batcave_nightlight_asg_name != "" ? [var.batcave_nightlight_asg_name] : []
+    content {
+      name  = "autoscalingGroups[3].maxSize"
+      value = var.batcave_nightlight_asg_max
+    }
+  }
+  
   set {
     name  = "resources.limits.cpu"
     value = "1"

--- a/variables.tf
+++ b/variables.tf
@@ -25,8 +25,12 @@ variable "helm_name" {
 
 variable "general_asg_name" {}
 variable "runner_asg_name" {}
-variable "batcave_website_asg_name" {}
-variable "batcave_nightlight_asg_name" {}
+variable "batcave_website_asg_name" {
+  default = ""
+}
+variable "batcave_nightlight_asg_name" {
+  default = ""
+}
 
 variable "general_asg_min" {
   default = "1"


### PR DESCRIPTION
Was getting the following error when not explicitly specifying ASG name for ADO-specific node groups, even when I didn't want to have ADO-specific node groups.
```
│ Error: No value for required variable
│
│   on variables.tf line 28:
│   28: variable "batcave_website_asg_name" {}
│
│ The root module input variable "batcave_website_asg_name" is not set, and
│ has no default value. Use a -var or -var-file command line argument to
│ provide a value for this variable.
╵
╷
│ Error: No value for required variable
│
│   on variables.tf line 29:
│   29: variable "batcave_nightlight_asg_name" {}
│
│ The root module input variable "batcave_nightlight_asg_name" is not set,
│ and has no default value. Use a -var or -var-file command line argument to
│ provide a value for this variable.
```

Solution was to dynamically create ASGs using `dynamic "set" {...}`. I don't like this solution but I'm unable to create a fresh dev env without it